### PR TITLE
Fix inaccessible URL validation

### DIFF
--- a/Sources/Sugar/Validators/URL.swift
+++ b/Sources/Sugar/Validators/URL.swift
@@ -5,6 +5,8 @@ private let regex = "^(?:(?:https?|ftp):\\/\\/)(?:\\S+(?::\\S*)?@)?(?:(?!(?:10|1
 
 public struct URL: Validator {
 
+    public init() {}
+    
     public func validate(_ input: String) throws {
         guard input.range(of: regex, options: .regularExpression) != nil else {
             throw error("Invalid URL.")


### PR DESCRIPTION
Nevertheless structs give you an `init()` for free. The default access level of Swift is `internal` which is unhandy in a package if the struct was meant to be used outside of the package 😊