### PR TITLE
Add dateBySetting(hour: Int, minute: Int, second: Int)

### DIFF
--- a/Sources/Sugar/Date+Sugar.swift
+++ b/Sources/Sugar/Date+Sugar.swift
@@ -212,6 +212,23 @@ extension Date {
         let date = Calendar.current.date(byAdding: components, to: self.startOfMonth())
         return (date?.addingTimeInterval(-1))!
     }
+
+    /// Set hour/min/sec of a date
+    ///
+    /// Replaces `Calendar().date(bySettingHour hour: Int, minute: Int, ...)` which is not
+    /// running on Linux yet.
+    ///
+    /// - Parameters:
+    ///   - hour: Int
+    ///   - minute: Int
+    ///   - second: Int
+    /// - Returns: Date?
+    public func dateBySetting(hour: Int, minute: Int, second: Int) -> Date? {
+
+        let dateComponents = Calendar.current.dateComponents([.year, .month, .day], from: self)
+        guard let date = Calendar.current.date(from: dateComponents) else { return nil }
+        return date.addingTimeInterval(TimeInterval(hour.hourInSec + minute.minInSec + second))
+    }
     
     //MARK:  Custom parsers
     

--- a/Tests/SugarTests/DateSugarTests.swift
+++ b/Tests/SugarTests/DateSugarTests.swift
@@ -83,6 +83,16 @@ class DateSugarTests: XCTestCase {
         let dateTimeStr = "2016-01-15 12:23:45"
         XCTAssertEqual(try Date.parse(.dateTime, dateTimeStr)?.addDays(30).toDateTimeString(), "2016-02-14 12:23:45")
     }
+
+    func testSetTimeForDate() {
+        let dateTimeStr = "2016-01-15 12:23:45"
+        XCTAssertEqual(try Date.parse(.dateTime, dateTimeStr)?.dateBySetting(hour: 1, minute: 2, second: 3)!.toDateTimeString(), "2016-01-15 01:02:03")
+    }
+
+    func testSetTimeForDateOverflow() {
+        let dateTimeStr = "2016-01-15 12:23:45"
+        XCTAssertEqual(try Date.parse(.dateTime, dateTimeStr)?.dateBySetting(hour: 0, minute: 59, second: 61)!.toDateTimeString(), "2016-01-15 01:00:01")
+    }
     
     func testStartOfMonth() {
         let dateTimeStr = "2016-01-15 12:23:45"
@@ -268,6 +278,10 @@ class DateSugarTests: XCTestCase {
             ("testAddMultipleDays", testAddMultipleDays),
             ("testAddMultipleDaysOverMonth", testAddMultipleDaysOverMonth),
             ("testStartOfMonth", testStartOfMonth),
+
+            ("testSetTimeForDate", testSetTimeForDate),
+            ("testSetTimeForDateOverflow", testSetTimeForDateOverflow),
+
             /*
             ("testEndOfMonthVerySmall", testEndOfMonthVerySmall),
             ("testEndOfMonthLarge", testEndOfMonthLarge),


### PR DESCRIPTION
Imitates `Calendar().date(bySettingHour hour: Int, minute: Int, ...)` which does not run on Linux.
Allows to set hour/min/sec of a specific date.