### PR TITLE
Add dateBySetting(hour: Int, minute: Int, second: Int) to Sugar 3.x

### DIFF
--- a/Sources/Sugar/Helpers/Date.swift
+++ b/Sources/Sugar/Helpers/Date.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 public extension Date {
+
+    static let hourInSec = 3600
+    static let minInSec = 60
+
     public static func startOfMonth() -> Date? {
         return Date().startOfMonth()
     }
@@ -36,5 +40,22 @@ public extension Date {
             byAdding: DateComponents(day: -days),
             to: self
         )
+    }
+
+    /// Set hour/min/sec of a date
+    ///
+    /// Replaces `Calendar().date(bySettingHour hour: Int, minute: Int, ...)` which is not
+    /// running on Linux yet.
+    ///
+    /// - Parameters:
+    ///   - hour: Int
+    ///   - minute: Int
+    ///   - second: Int
+    /// - Returns: Date?
+    public func dateBySetting(hour: Int, minute: Int, second: Int) -> Date? {
+
+        let dateComponents = Calendar.current.dateComponents([.year, .month, .day], from: self)
+        guard let date = Calendar.current.date(from: dateComponents) else { return nil }
+        return date.addingTimeInterval(TimeInterval(hour * Date.hourInSec + minute * Date.minInSec + second))
     }
 }


### PR DESCRIPTION
Imitates Calendar().date(bySettingHour hour: Int, minute: Int, ...) which does not run on Linux.
Allows to set hour/min/sec of a specific date.

See #58 