### PR TITLE
Change token to Bearer

### DIFF
--- a/Sources/Sugar/Middlewares/SimpleAuthMiddleware.swift
+++ b/Sources/Sugar/Middlewares/SimpleAuthMiddleware.swift
@@ -14,7 +14,7 @@ public final class SimpleAuthMiddleware: Middleware {
 
         guard
             let header = request.auth.header,
-            header.string == token
+            header.string == ("Bearer \(token)")
         else {
             throw Abort.unauthorized
         }


### PR DESCRIPTION
Changing the token format to 'Bearer' allows to utilize authorization headers from 3rd party apps (e.g. Postman).