### PR TITLE
Improved jwt stuff

### DIFF
--- a/Sources/Sugar/Authentication/AuthenticationError.swift
+++ b/Sources/Sugar/Authentication/AuthenticationError.swift
@@ -10,6 +10,7 @@ public enum AuthenticationError: String, Error {
     case incorrectOldPassword
     case passwordWithoutUsernameOrOldPassword
     case malformedPayload
+    case missingToken
 }
 
 // MARK: - AbortError
@@ -25,6 +26,7 @@ extension AuthenticationError: AbortError {
         case .incorrectOldPassword: return .unprocessableEntity
         case .passwordWithoutUsernameOrOldPassword: return .unprocessableEntity
         case .malformedPayload: return .badRequest
+        case .missingToken: return .unauthorized
         }
     }
 
@@ -47,6 +49,8 @@ extension AuthenticationError: AbortError {
             return "Password should only be provided when updating it or updating the username."
         case .malformedPayload:
             return "Malformed JWT payload received."
+        case .missingToken:
+            return "Could not find a Bearer token."
         }
     }
 }

--- a/Sources/Sugar/Authentication/ExpireableJWTSigner.swift
+++ b/Sources/Sugar/Authentication/ExpireableJWTSigner.swift
@@ -14,4 +14,18 @@ public struct ExpireableJWTSigner {
         self.expirationPeriod = expirationPeriod
         self.signer = signer
     }
+
+    public func sign<Payload>(_ jwt: inout JWT<Payload>) throws -> Data {
+        return try self.signer.sign(&jwt)
+    }
+
+    public func verify(_ signature: Data, header: Data, payload: Data) throws -> Bool {
+        return try self.signer.verify(signature, header: header, payload: payload)
+    }
+}
+
+public extension JWT {
+    public init(from string: String, verifiedUsing signer: ExpireableJWTSigner) throws {
+        try self.init(from: string, verifiedUsing: signer.signer)
+    }
 }

--- a/Sources/Sugar/Authentication/JWTAuthenticationMiddleware.swift
+++ b/Sources/Sugar/Authentication/JWTAuthenticationMiddleware.swift
@@ -14,6 +14,7 @@ public final class JWTAuthenticationMiddleware<A: JWTAuthenticatable>: Middlewar
     /// Creates a new JWT Authentication Middleware
     ///
     /// - Parameters:
+    ///   - key: the key of the signer you want to use
     ///   - shouldAuthenticate: whether full authentication (which usually includes a database
     ///     query) should be performed
     public init(using key: String, shouldAuthenticate: Bool = true) {

--- a/Sources/Sugar/Authentication/JWTAuthenticationMiddleware.swift
+++ b/Sources/Sugar/Authentication/JWTAuthenticationMiddleware.swift
@@ -33,7 +33,7 @@ public final class JWTAuthenticationMiddleware<A: JWTAuthenticatable>: Middlewar
         }
 
         guard let bearer = req.http.headers.bearerAuthorization else {
-            return try next.respond(to: req)
+            throw AuthenticationError.missingToken
         }
 
         let jwt: JWT<A.JWTPayload>

--- a/Sources/Sugar/Authentication/Service/CertService.swift
+++ b/Sources/Sugar/Authentication/Service/CertService.swift
@@ -1,0 +1,28 @@
+//
+//  SignerService.swift
+//  Sugar
+//
+//  Created by Gustavo Perdomo on 6/9/18.
+//
+
+import Foundation
+import Crypto
+import JWT
+
+public final class CertService: SignerService {
+    public var signer: ExpireableJWTSigner
+    
+    public init(certificate: String, expirationPeriod: TimeInterval, algorithm: DigestAlgorithm = .sha256) throws {
+        let key = try RSAKey.public(certificate: certificate)
+        let signer: JWTSigner
+        
+        switch algorithm {
+        case .sha256: signer = JWTSigner.rs256(key: key)
+        case .sha384: signer = JWTSigner.rs384(key: key)
+        case .sha512: signer = JWTSigner.rs512(key: key)
+        default: throw SignerServiceError(identifier: "badRSAAlgorithm", reason: "RSA signing requires SHA256, SHA384, or SHA512 algorithm", status: .internalServerError)
+        }
+        
+        self.signer = ExpireableJWTSigner(expirationPeriod: expirationPeriod, signer: signer)
+    }
+}

--- a/Sources/Sugar/Authentication/Service/CertService.swift
+++ b/Sources/Sugar/Authentication/Service/CertService.swift
@@ -1,10 +1,3 @@
-//
-//  SignerService.swift
-//  Sugar
-//
-//  Created by Gustavo Perdomo on 6/9/18.
-//
-
 import Foundation
 import Crypto
 import JWT
@@ -17,9 +10,9 @@ public final class CertService: SignerService {
         let signer: JWTSigner
         
         switch algorithm {
-        case .sha256: signer = JWTSigner.rs256(key: key)
-        case .sha384: signer = JWTSigner.rs384(key: key)
-        case .sha512: signer = JWTSigner.rs512(key: key)
+        case .sha256: signer = .rs256(key: key)
+        case .sha384: signer = .rs384(key: key)
+        case .sha512: signer = .rs512(key: key)
         default: throw SignerServiceError(identifier: "badRSAAlgorithm", reason: "RSA signing requires SHA256, SHA384, or SHA512 algorithm", status: .internalServerError)
         }
         

--- a/Sources/Sugar/Authentication/Service/HMACService.swift
+++ b/Sources/Sugar/Authentication/Service/HMACService.swift
@@ -1,0 +1,26 @@
+//
+//  SignerService.swift
+//  Sugar
+//
+//  Created by Gustavo Perdomo on 6/9/18.
+//
+
+import Foundation
+import Crypto
+import JWT
+
+public final class HMACService: SignerService {
+    public let signer: ExpireableJWTSigner
+    
+    public init(secret: String, expirationPeriod: TimeInterval, algorithm: DigestAlgorithm = .sha256) throws {
+        let signer: JWTSigner
+        switch algorithm {
+        case .sha256: signer = JWTSigner.hs256(key: Data(secret.utf8))
+        case .sha384: signer = JWTSigner.hs384(key: Data(secret.utf8))
+        case .sha512: signer = JWTSigner.hs512(key: Data(secret.utf8))
+        default: throw SignerServiceError(identifier: "badHMACAlgorithm", reason: "HMAC signing requires SHA256, SHA384, or SHA512 algorithm", status: .internalServerError)
+        }
+        
+        self.signer = ExpireableJWTSigner(expirationPeriod: expirationPeriod, signer: signer)
+    }
+}

--- a/Sources/Sugar/Authentication/Service/HMACService.swift
+++ b/Sources/Sugar/Authentication/Service/HMACService.swift
@@ -1,10 +1,3 @@
-//
-//  SignerService.swift
-//  Sugar
-//
-//  Created by Gustavo Perdomo on 6/9/18.
-//
-
 import Foundation
 import Crypto
 import JWT
@@ -15,9 +8,9 @@ public final class HMACService: SignerService {
     public init(secret: String, expirationPeriod: TimeInterval, algorithm: DigestAlgorithm = .sha256) throws {
         let signer: JWTSigner
         switch algorithm {
-        case .sha256: signer = JWTSigner.hs256(key: Data(secret.utf8))
-        case .sha384: signer = JWTSigner.hs384(key: Data(secret.utf8))
-        case .sha512: signer = JWTSigner.hs512(key: Data(secret.utf8))
+        case .sha256: signer = .hs256(key: Data(secret.utf8))
+        case .sha384: signer = .hs384(key: Data(secret.utf8))
+        case .sha512: signer = .hs512(key: Data(secret.utf8))
         default: throw SignerServiceError(identifier: "badHMACAlgorithm", reason: "HMAC signing requires SHA256, SHA384, or SHA512 algorithm", status: .internalServerError)
         }
         

--- a/Sources/Sugar/Authentication/Service/RSAService.swift
+++ b/Sources/Sugar/Authentication/Service/RSAService.swift
@@ -1,10 +1,3 @@
-//
-//  SignerService.swift
-//  Sugar
-//
-//  Created by Gustavo Perdomo on 6/9/18.
-//
-
 import Foundation
 import Crypto
 import JWT
@@ -12,37 +5,33 @@ import JWT
 public final class RSAService: SignerService {
     public let signer: ExpireableJWTSigner
     
-    public init(secret: String, type: RSAKeyType = .private, expirationPeriod: TimeInterval, algorithm: DigestAlgorithm = .sha256) throws {
+    public init(key: RSAKey, expirationPeriod: TimeInterval, algorithm: DigestAlgorithm = .sha256) throws {
         let signer: JWTSigner
-        let key: RSAKey
-        
-        switch type {
-        case .public: key = try RSAKey.public(pem: secret)
-        case .private: key = try RSAKey.private(pem: secret)
-        }
-        
         switch algorithm {
-        case .sha256: signer = JWTSigner.rs256(key: key)
-        case .sha384: signer = JWTSigner.rs384(key: key)
-        case .sha512: signer = JWTSigner.rs512(key: key)
+        case .sha256: signer = .rs256(key: key)
+        case .sha384: signer = .rs384(key: key)
+        case .sha512: signer = .rs512(key: key)
         default: throw SignerServiceError(identifier: "badRSAAlgorithm", reason: "RSA signing requires SHA256, SHA384, or SHA512 algorithm", status: .internalServerError)
         }
         
         self.signer = ExpireableJWTSigner(expirationPeriod: expirationPeriod, signer: signer)
     }
     
-    public init(n: String, e: String, d: String? = nil, expirationPeriod: TimeInterval, algorithm: DigestAlgorithm = .sha256)throws {
-        let key = try RSAKey.components(n: n, e: e, d: d)
-        let signer: JWTSigner
+    public convenience init(secret: String, type: RSAKeyType = .private, expirationPeriod: TimeInterval, algorithm: DigestAlgorithm = .sha256) throws {
+        let key: RSAKey
         
-        switch algorithm {
-        case .sha256: signer = JWTSigner.rs256(key: key)
-        case .sha384: signer = JWTSigner.rs384(key: key)
-        case .sha512: signer = JWTSigner.rs512(key: key)
-        default: throw SignerServiceError(identifier: "badRSAAlgorithm", reason: "RSA signing requires SHA256, SHA384, or SHA512 algorithm", status: .internalServerError)
+        switch type {
+        case .public: key = try .public(pem: secret)
+        case .private: key = try .private(pem: secret)
         }
         
-        self.signer = ExpireableJWTSigner(expirationPeriod: expirationPeriod, signer: signer)
+        try self.init(key: key, expirationPeriod: expirationPeriod, algorithm: algorithm)
+    }
+    
+    public convenience init(n: String, e: String, d: String? = nil, expirationPeriod: TimeInterval, algorithm: DigestAlgorithm = .sha256) throws {
+        let key = try RSAKey.components(n: n, e: e, d: d)
+        
+        try self.init(key: key, expirationPeriod: expirationPeriod, algorithm: algorithm)
     }
 }
 

--- a/Sources/Sugar/Authentication/Service/RSAService.swift
+++ b/Sources/Sugar/Authentication/Service/RSAService.swift
@@ -1,0 +1,48 @@
+//
+//  SignerService.swift
+//  Sugar
+//
+//  Created by Gustavo Perdomo on 6/9/18.
+//
+
+import Foundation
+import Crypto
+import JWT
+
+public final class RSAService: SignerService {
+    public let signer: ExpireableJWTSigner
+    
+    public init(secret: String, type: RSAKeyType = .private, expirationPeriod: TimeInterval, algorithm: DigestAlgorithm = .sha256) throws {
+        let signer: JWTSigner
+        let key: RSAKey
+        
+        switch type {
+        case .public: key = try RSAKey.public(pem: secret)
+        case .private: key = try RSAKey.private(pem: secret)
+        }
+        
+        switch algorithm {
+        case .sha256: signer = JWTSigner.rs256(key: key)
+        case .sha384: signer = JWTSigner.rs384(key: key)
+        case .sha512: signer = JWTSigner.rs512(key: key)
+        default: throw SignerServiceError(identifier: "badRSAAlgorithm", reason: "RSA signing requires SHA256, SHA384, or SHA512 algorithm", status: .internalServerError)
+        }
+        
+        self.signer = ExpireableJWTSigner(expirationPeriod: expirationPeriod, signer: signer)
+    }
+    
+    public init(n: String, e: String, d: String? = nil, expirationPeriod: TimeInterval, algorithm: DigestAlgorithm = .sha256)throws {
+        let key = try RSAKey.components(n: n, e: e, d: d)
+        let signer: JWTSigner
+        
+        switch algorithm {
+        case .sha256: signer = JWTSigner.rs256(key: key)
+        case .sha384: signer = JWTSigner.rs384(key: key)
+        case .sha512: signer = JWTSigner.rs512(key: key)
+        default: throw SignerServiceError(identifier: "badRSAAlgorithm", reason: "RSA signing requires SHA256, SHA384, or SHA512 algorithm", status: .internalServerError)
+        }
+        
+        self.signer = ExpireableJWTSigner(expirationPeriod: expirationPeriod, signer: signer)
+    }
+}
+

--- a/Sources/Sugar/Authentication/Service/SignerService.swift
+++ b/Sources/Sugar/Authentication/Service/SignerService.swift
@@ -1,0 +1,19 @@
+//
+//  SignerService.swift
+//  Sugar
+//
+//  Created by Gustavo Perdomo on 6/9/18.
+//
+
+import Debugging
+import Vapor
+
+public struct SignerServiceError: Debuggable, AbortError, Error {
+    public let identifier: String
+    public let reason: String
+    public let status: HTTPResponseStatus
+}
+
+public protocol SignerService: Service {
+    var signer: ExpireableJWTSigner { get }
+}

--- a/Sources/Sugar/Authentication/Service/SignerService.swift
+++ b/Sources/Sugar/Authentication/Service/SignerService.swift
@@ -1,10 +1,3 @@
-//
-//  SignerService.swift
-//  Sugar
-//
-//  Created by Gustavo Perdomo on 6/9/18.
-//
-
 import Debugging
 import Vapor
 

--- a/Sources/Sugar/Authentication/Service/SignersService.swift
+++ b/Sources/Sugar/Authentication/Service/SignersService.swift
@@ -1,0 +1,47 @@
+import Vapor
+
+public final class SignersService: Service {
+    private var storage: [String: ExpireableJWTSigner]
+    
+    /// Create a new collection of `ExpireableJWTSigner`
+    public init(signers: [String: ExpireableJWTSigner]) {
+        self.storage = signers
+    }
+    
+    /// Gets an instance of `ExpireableJWTSigner` parsed from the value associated with the `key`
+    ///
+    /// - Parameter key: key to retrieve
+    /// - Returns: A optional `ExpireableJWTSigner`
+    public func get(_ key: String) -> ExpireableJWTSigner? {
+        return storage[key]
+    }
+    
+    /// Sets the value to an `ExpireableJWTSigner` at the supplied `key`.
+    ///
+    /// - Parameters:
+    ///   - key: key to set
+    ///   - signer: An `ExpireableJWTSigner` item to set.
+    public func set(_ key: String, signer: ExpireableJWTSigner) {
+        storage[key] = signer
+    }
+    
+    /// Removes the value associated with the `key`.
+    ///
+    /// - Parameter key: key to remove
+    public func remove(_ key: String) {
+        storage[key] = nil
+    }
+    
+    
+    /// Gets an instance of `ExpireableJWTSigner` parsed from the value associated with the `key`
+    ///
+    /// - Parameter key: key to retrieve
+    /// - Returns: A `ExpireableJWTSigner`
+    /// - Throws: SignerServiceError if key not exists
+    public func require(_ key: String) throws -> ExpireableJWTSigner {
+        guard let signer = self.get(key) else {
+            throw SignerServiceError(identifier: "unknownKID", reason: "No \(ExpireableJWTSigner.self) are available for the supplied `key`", status: .internalServerError)
+        }
+        return signer
+    }
+}

--- a/Sources/Sugar/Authentication/Service/SignersService.swift
+++ b/Sources/Sugar/Authentication/Service/SignersService.swift
@@ -42,7 +42,7 @@ public final class SignersService: Service {
     ///
     /// - Parameter key: key to retrieve
     /// - Returns: A `ExpireableJWTSigner`
-    /// - Throws: SignerServiceError if key not exists
+    /// - Throws: SignerServiceError if key does not exist
     public func require(_ key: String) throws -> ExpireableJWTSigner {
         guard let signer = self.get(key) else {
             throw SignerServiceError(identifier: "unknownKID", reason: "No \(ExpireableJWTSigner.self) are available for the supplied `key`", status: .internalServerError)

--- a/Sources/Sugar/Authentication/Service/SignersService.swift
+++ b/Sources/Sugar/Authentication/Service/SignersService.swift
@@ -8,6 +8,11 @@ public final class SignersService: Service {
         self.storage = signers
     }
     
+    /// Create a new empty collection of `ExpireableJWTSigner`
+    public init() {
+        self.storage = [:]
+    }
+    
     /// Gets an instance of `ExpireableJWTSigner` parsed from the value associated with the `key`
     ///
     /// - Parameter key: key to retrieve


### PR DESCRIPTION
Now, to use a JWTMiddleware we need to pass the signer to all controllers through init parameter or create a new signer in every controller where is needed, which can produce some problems if you change the secret and forgot change in some places, instead of that, this PR introduce a Signer service to allow the creation of the JWTSigner in the configure main and get that signer service when is needed