### PR TITLE
Fix RedisError to be able to compile again

### DIFF
--- a/Sources/Sugar/Helpers/Redis.swift
+++ b/Sources/Sugar/Helpers/Redis.swift
@@ -4,7 +4,7 @@ extension RedisClient {
     public func expire(_ key: String, after deadline: Int) -> Future<Int> {
         let resp = command("EXPIRE", [RedisData(bulk: key), RedisData(bulk: "\(deadline)")]).map(to: Int.self) { data in
             guard let value = data.int else {
-                throw RedisError(identifier: "expire", reason: "Could not convert resp to int", source: .capture())
+                throw RedisError(identifier: "expire", reason: "Could not convert response to int")
             }
 
             return value


### PR DESCRIPTION
Since the new Redis 3.0.0 release the RedisError init signature has changed causing the package not to compile.

This patch removes `.capture()` from the init and makes the package work with Redis 3.0.0