### PR TITLE
Initiate non-optional Bool from String

### DIFF
--- a/Sources/Sugar/Helpers/Bool.swift
+++ b/Sources/Sugar/Helpers/Bool.swift
@@ -1,0 +1,5 @@
+extension Bool {
+    init(from string: String) {
+        self = ["1", "true"].contains(string.lowercased())
+    }
+}


### PR DESCRIPTION
A Bool can now be initiated using a string representation.
• It will  return `true` in case `"1"` or `"true"` is supplied.
• Returns `false` for any other case.

Useful when booleans are set through environment variables 😊

Credits to @cweinberger:
https://github.com/nodes-projects/stark-vapor/blob/develop/Sources/App/Helpers/Bool%2BfromString.swift