### PR TITLE
Add query helper on URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2
 jobs:
   MacOS:
     macos:
-      xcode: "9.3.0"
+      xcode: "10.0.0"
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v3-spm-deps-{{ checksum "Package.swift" }}
+            - v1-spm-deps-{{ checksum "Package.swift" }}
       - run:
-          name: Install CMySQL and CTLS
+          name: Install dependencies
           command: |
             brew tap vapor/homebrew-tap
             brew install cmysql
@@ -19,7 +19,7 @@ jobs:
           name: Build and Run Tests
           no_output_timeout: 1800
           command: |
-            swift package generate-xcodeproj --enable-code-coverage    
+            swift package generate-xcodeproj --enable-code-coverage
             xcodebuild -scheme Sugar-Package -enableCodeCoverage YES test | xcpretty
       - run:
           name: Report coverage to Codecov
@@ -31,14 +31,14 @@ jobs:
             - .build
   Linux:
     docker:
-      - image: nodesvapor/vapor-ci:swift-4.1
+      - image: nodesvapor/vapor-ci:swift-4.2
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v4-spm-deps-{{ checksum "Package.swift" }}
+            - v2-spm-deps-{{ checksum "Package.swift" }}
       - run:
-          name: Copy Package file
+          name: Copy Package File
           command: cp Package.swift res
       - run:
           name: Build and Run Tests
@@ -46,7 +46,7 @@ jobs:
           command: |
             swift test -Xswiftc -DNOJSON
       - run:
-          name: Restoring Package file
+          name: Restoring Package File
           command: mv res Package.swift
       - save_cache:
           key: v2-spm-deps-{{ checksum "Package.swift" }}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Sugar 🍬
-[![Swift Version](https://img.shields.io/badge/Swift-4.1-brightgreen.svg)](http://swift.org)
+[![Swift Version](https://img.shields.io/badge/Swift-4.2-brightgreen.svg)](http://swift.org)
 [![Vapor Version](https://img.shields.io/badge/Vapor-3-30B6FC.svg)](http://vapor.codes)
 [![Circle CI](https://circleci.com/gh/nodes-vapor/sugar/tree/master.svg?style=shield)](https://circleci.com/gh/nodes-vapor/sugar)
 [![codebeat badge](https://codebeat.co/badges/54770476-a759-47f8-9372-1009267a56e0)](https://codebeat.co/projects/github-com-nodes-vapor-sugar-master)

--- a/Sources/Sugar/Authentication/Payload.swift
+++ b/Sources/Sugar/Authentication/Payload.swift
@@ -20,7 +20,7 @@ public struct Payload: ExpireableSubjectPayload {
         self.exp = exp
         self.sub = sub
     }
-    
+
     /// See `JWTVerifiable`
     public func verify(using signer: JWTSigner) throws {
         try exp.verifyNotExpired()

--- a/Sources/Sugar/Helpers/Date.swift
+++ b/Sources/Sugar/Helpers/Date.swift
@@ -70,6 +70,8 @@ public extension Date {
 
         let dateComponents = Calendar.current.dateComponents([.year, .month, .day], from: self)
         guard let date = Calendar.current.date(from: dateComponents) else { return nil }
-        return date.addingTimeInterval(TimeInterval(hour * Date.hourInSec + minute * Date.minInSec + second))
+        return date.addingTimeInterval(
+            TimeInterval(hour * Date.hourInSec + minute * Date.minInSec + second)
+        )
     }
 }

--- a/Sources/Sugar/Helpers/Model.swift
+++ b/Sources/Sugar/Helpers/Model.swift
@@ -50,7 +50,10 @@ extension Model where Database: SchemaSupporting {
         excluding excludedProperties: [ReflectedProperty?]
     ) throws {
         guard let idProperty = try Self.reflectProperty(forKey: idKey) else {
-            throw FluentError(identifier: "idProperty", reason: "Unable to reflect ID property for `\(Self.self)`.")
+            throw FluentError(
+                identifier: "idProperty",
+                reason: "Unable to reflect ID property for `\(Self.self)`."
+            )
         }
 
         let properties = try Self.reflectProperties(depth: 0).filter { property in

--- a/Sources/Sugar/Helpers/Redis.swift
+++ b/Sources/Sugar/Helpers/Redis.swift
@@ -2,7 +2,9 @@ import Redis
 
 extension RedisClient {
     public func expire(_ key: String, after deadline: Int) -> Future<Int> {
-        let resp = command("EXPIRE", [RedisData(bulk: key), RedisData(bulk: "\(deadline)")]).map(to: Int.self) { data in
+        let resp = command(
+            "EXPIRE", [RedisData(bulk: key), RedisData(bulk: "\(deadline)")]).map(to: Int.self
+        ) { data in
             guard let value = data.int else {
                 throw RedisError(identifier: "expire", reason: "Could not convert response to int")
             }
@@ -13,14 +15,22 @@ extension RedisClient {
         return resp
     }
 
-    public func set<E>(_ key: String, to data: E, expiration: Int) -> Future<Int> where E: RedisDataConvertible {
+    public func set<E>(
+        _ key: String,
+        to data: E,
+        expiration: Int
+    ) -> Future<Int> where E: RedisDataConvertible {
         return set(key, to: data)
             .flatMap {
                 return self.expire(key, after: expiration)
             }
     }
 
-    public func jsonSet<E>(_ key: String, to entity: E, expiration: Int) -> Future<Int> where E: Encodable {
+    public func jsonSet<E>(
+        _ key: String,
+        to entity: E,
+        expiration: Int
+    ) -> Future<Int> where E: Encodable {
         do {
             return try set(key, to: JSONEncoder().encode(entity))
                 .flatMap {

--- a/Sources/Sugar/Helpers/Render+userInfo.swift
+++ b/Sources/Sugar/Helpers/Render+userInfo.swift
@@ -36,7 +36,7 @@ extension ViewRenderer {
         userInfo: [AnyHashable: Any] = [:],
         on req: Request
     ) -> Future<View> {
-        return render(path, Dictionary<String, String>(), userInfo: userInfo, on: req)
+        return render(path, [String: String](), userInfo: userInfo, on: req)
     }
 }
 

--- a/Sources/Sugar/Helpers/URL.swift
+++ b/Sources/Sugar/Helpers/URL.swift
@@ -15,7 +15,7 @@ public extension URL {
         guard
             let items = URLComponents(url: URL, resolvingAgainstBaseURL: false)?.queryItems
         else {
-            return nil
+            return self
         }
 
         return addQueryItems(items)

--- a/Sources/Sugar/Helpers/URL.swift
+++ b/Sources/Sugar/Helpers/URL.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension URL {
-    public func addQueryItems(_ item: [URLQueryItem]) -> URL? {
+    public func addQueryItems(_ item: [URLQueryItem]) -> URL {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
             return nil
         }

--- a/Sources/Sugar/Helpers/URL.swift
+++ b/Sources/Sugar/Helpers/URL.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public extension URL {
+    public func addQueryItems(_ item: [URLQueryItem]) -> URL? {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        let currentItems = components.queryItems ?? []
+        components.queryItems = currentItems + item
+        return components.url
+    }
+
+    public func addQueryItems(from URL: URL) -> URL? {
+        guard
+            let items = URLComponents(url: URL, resolvingAgainstBaseURL: false)?.queryItems
+        else {
+            return nil
+        }
+
+        return addQueryItems(items)
+    }
+}

--- a/Sources/Sugar/Helpers/URL.swift
+++ b/Sources/Sugar/Helpers/URL.swift
@@ -3,7 +3,7 @@ import Foundation
 public extension URL {
     public func addQueryItems(_ item: [URLQueryItem]) -> URL {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
-            return nil
+            return self
         }
 
         let currentItems = components.queryItems ?? []

--- a/Sources/Sugar/Helpers/URL.swift
+++ b/Sources/Sugar/Helpers/URL.swift
@@ -13,7 +13,7 @@ public extension URL {
 
     public func addQueryItems(from url: URL) -> URL {
         guard
-            let items = URLComponents(url: URL, resolvingAgainstBaseURL: false)?.queryItems
+            let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
         else {
             return self
         }

--- a/Sources/Sugar/Helpers/URL.swift
+++ b/Sources/Sugar/Helpers/URL.swift
@@ -8,7 +8,7 @@ public extension URL {
 
         let currentItems = components.queryItems ?? []
         components.queryItems = currentItems + item
-        return components.url
+        return components.url ?? self
     }
 
     public func addQueryItems(from url: URL) -> URL {

--- a/Sources/Sugar/Helpers/URL.swift
+++ b/Sources/Sugar/Helpers/URL.swift
@@ -11,7 +11,7 @@ public extension URL {
         return components.url
     }
 
-    public func addQueryItems(from URL: URL) -> URL? {
+    public func addQueryItems(from url: URL) -> URL {
         guard
             let items = URLComponents(url: URL, resolvingAgainstBaseURL: false)?.queryItems
         else {

--- a/Sources/Sugar/Middlewares/CurrentURLMiddleware.swift
+++ b/Sources/Sugar/Middlewares/CurrentURLMiddleware.swift
@@ -4,7 +4,7 @@ public final class CurrentURLProvider: Provider {
     public init() {}
 
     public func register(_ services: inout Services) throws {
-        services.register { container in
+        services.register { _ in
             return CurrentURLContainer()
         }
     }

--- a/Sources/Sugar/Middlewares/CurrentUserMiddleware.swift
+++ b/Sources/Sugar/Middlewares/CurrentUserMiddleware.swift
@@ -5,7 +5,7 @@ public final class CurrentUserProvider<U: Authenticatable>: Provider {
     public init() {}
 
     public func register(_ services: inout Services) throws {
-        services.register { container in
+        services.register { _ in
             return CurrentUserContainer<U>()
         }
     }


### PR DESCRIPTION
Added:
- Small helper on `URL` to make it easier to move query items across urls.
- Bumped to Swift 4.2
- Fixed Swiftlint errors