### PR TITLE
Nodes vapor 4pr

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Sugar 🍬
-[![Swift Version](https://img.shields.io/badge/Swift-4.2-brightgreen.svg)](http://swift.org)
+[![Swift Version](https://img.shields.io/badge/Swift-4.1-brightgreen.svg)](http://swift.org)
 [![Vapor Version](https://img.shields.io/badge/Vapor-3-30B6FC.svg)](http://vapor.codes)
 [![Circle CI](https://circleci.com/gh/nodes-vapor/sugar/tree/master.svg?style=shield)](https://circleci.com/gh/nodes-vapor/sugar)
 [![codebeat badge](https://codebeat.co/badges/54770476-a759-47f8-9372-1009267a56e0)](https://codebeat.co/projects/github-com-nodes-vapor-sugar-master)

--- a/Sources/Sugar/Helpers/Environment.swift
+++ b/Sources/Sugar/Helpers/Environment.swift
@@ -9,10 +9,6 @@ public extension Environment {
         return ProcessInfo.processInfo.environment[key] ?? fallback
     }
 
-    public static func get(_ key: String) -> String? {
-        return ProcessInfo.processInfo.environment[key]
-    }
-
     public static func assertGet(_ key: String) throws -> String {
         guard let value = Environment.get(key) else {
             throw Environment.EnvironmentError.keyNotFound(key: key)


### PR DESCRIPTION
This PR downgrades the swift dependency from 4.2 to 4.0 without any other changes and remove a duplicated get(key:) method already defined in Vapor/Service/Environment 3.0.0.