### PR TITLE
Add test for dateBySetting(hour:minute:second:calendar:)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,12 +52,36 @@ jobs:
           key: v4-spm-deps-{{ checksum "Package.swift" }}
           paths:
             - .build
+  Linux-Swift-5:
+    docker:
+      - image: nodesvapor/vapor-ci:swift-5.0
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v5-spm-deps-{{ checksum "Package.swift" }}
+      - run:
+          name: Copy Package File
+          command: cp Package.swift res
+      - run:
+          name: Build and Run Tests
+          no_output_timeout: 1800
+          command: |
+            swift test -Xswiftc -DNOJSON
+      - run:
+          name: Restoring Package File
+          command: mv res Package.swift
+      - save_cache:
+          key: v5-spm-deps-{{ checksum "Package.swift" }}
+          paths:
+            - .build
 workflows:
   version: 2
   build-and-test:
     jobs:
       - MacOS
       - Linux
+      - Linux-Swift-5
 experimental:
   notify:
     branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
 version: 2
 jobs:
-  MacOS:
+  MacOS-Swift-4.2:
     macos:
       xcode: "10.1.0"
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-spm-deps-{{ checksum "Package.swift" }}
+            - macos-swift4.2-v1-spm-deps-{{ checksum "Package.swift" }}
       - run:
           name: Install dependencies
           command: |
@@ -26,17 +26,43 @@ jobs:
           command: |
             bash <(curl -s https://codecov.io/bash)
       - save_cache:
-          key: v1-spm-deps-{{ checksum "Package.swift" }}
+          key: macos-swift4.2-v1-spm-deps-{{ checksum "Package.swift" }}
           paths:
             - .build
-  Linux:
+  MacOS-Swift-5:
+    macos:
+      xcode: "10.2.1"
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - macos-swift5-v1-spm-deps-{{ checksum "Package.resolved" }}
+      - run:
+          name: Install dependencies
+          command: |
+            export HOMEBREW_NO_AUTO_UPDATE=1
+            brew tap vapor/homebrew-tap
+            brew install cmysql
+            brew install ctls
+            brew install libressl
+            brew install cstack
+      - run:
+          name: Build and Run Tests
+          no_output_timeout: 1800
+          command: |
+            swift test -Xswiftc -DNOJSON
+      - save_cache:
+          key: macos-swift5-v1-spm-deps-{{ checksum "Package.resolved" }}
+          paths:
+            - .build
+  Linux-Swift-4.2:
     docker:
       - image: nodesvapor/vapor-ci:swift-4.2
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v4-spm-deps-{{ checksum "Package.swift" }}
+            - linux-swift4.2-v1-spm-deps-{{ checksum "Package.swift" }}
       - run:
           name: Copy Package File
           command: cp Package.swift res
@@ -49,7 +75,7 @@ jobs:
           name: Restoring Package File
           command: mv res Package.swift
       - save_cache:
-          key: v4-spm-deps-{{ checksum "Package.swift" }}
+          key: linux-swift4.2-v1-spm-deps-{{ checksum "Package.swift" }}
           paths:
             - .build
   Linux-Swift-5:
@@ -59,7 +85,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-spm-deps-{{ checksum "Package.swift" }}
+            - linux-swift5-v1-spm-deps-{{ checksum "Package.swift" }}
       - run:
           name: Copy Package File
           command: cp Package.swift res
@@ -72,15 +98,16 @@ jobs:
           name: Restoring Package File
           command: mv res Package.swift
       - save_cache:
-          key: v5-spm-deps-{{ checksum "Package.swift" }}
+          key: linux-swift5-v1-spm-deps-{{ checksum "Package.swift" }}
           paths:
             - .build
 workflows:
   version: 2
   build-and-test:
     jobs:
-      - MacOS
-      - Linux
+      - MacOS-Swift-4.2
+      - MacOS-Swift-5
+      - Linux-Swift-4.2
       - Linux-Swift-5
 experimental:
   notify:

--- a/Sources/Sugar/Helpers/Date.swift
+++ b/Sources/Sugar/Helpers/Date.swift
@@ -70,7 +70,7 @@ public extension Date {
         hour: Int,
         minute: Int,
         second: Int,
-        calendar: Calendar = .current
+        calendar: Calendar = Calendar(identifier: .gregorian)
     ) -> Date? {
         let dateComponents = calendar.dateComponents([.year, .month, .day], from: self)
         guard let date = calendar.date(from: dateComponents) else { return nil }

--- a/Tests/SugarTests/Helpers/DateTests.swift
+++ b/Tests/SugarTests/Helpers/DateTests.swift
@@ -1,0 +1,25 @@
+import Sugar
+import Vapor
+import XCTest
+
+final class DateTests: XCTestCase {
+
+    // MARK: func dateBySetting(hour:minute:second:calendar:)
+
+    func testDateBySettingHourMinuteSecond() {
+
+        let calendarComponents: Set<Calendar.Component> = Set([.year, .month, .day, .hour, .minute, .second])
+
+        let today = Date()
+        let todayStartOfDay = today.dateBySetting(hour: 0, minute: 0, second: 0, calendar: .current)!
+        let todayComps = Calendar.current.dateComponents(calendarComponents, from: today)
+        let todayStartOfDayComps = Calendar.current.dateComponents(calendarComponents, from: todayStartOfDay)
+
+        XCTAssertEqual(todayStartOfDayComps.year, todayComps.year, "Year changed!")
+        XCTAssertEqual(todayStartOfDayComps.month, todayComps.month, "Month changed!")
+        XCTAssertEqual(todayStartOfDayComps.day, todayComps.day, "Day changed!")
+        XCTAssertEqual(todayStartOfDayComps.hour, 0, "Hour not correct")
+        XCTAssertEqual(todayStartOfDayComps.minute, 0, "Minute not correct")
+        XCTAssertEqual(todayStartOfDayComps.second, 0, "Second not correct")
+    }
+}

--- a/Tests/SugarTests/Helpers/DateTests.swift
+++ b/Tests/SugarTests/Helpers/DateTests.swift
@@ -11,7 +11,7 @@ final class DateTests: XCTestCase {
         let calendarComponents: Set<Calendar.Component> = Set([.year, .month, .day, .hour, .minute, .second])
 
         let today = Date()
-        let todayStartOfDay = today.dateBySetting(hour: 0, minute: 0, second: 0, calendar: .current)!
+        let todayStartOfDay = today.dateBySetting(hour: 0, minute: 0, second: 0)!
         let todayComps = Calendar.current.dateComponents(calendarComponents, from: today)
         let todayStartOfDayComps = Calendar.current.dateComponents(calendarComponents, from: todayStartOfDay)
 

--- a/Tests/SugarTests/Helpers/DateTests.swift
+++ b/Tests/SugarTests/Helpers/DateTests.swift
@@ -10,10 +10,12 @@ final class DateTests: XCTestCase {
 
         let calendarComponents: Set<Calendar.Component> = Set([.year, .month, .day, .hour, .minute, .second])
 
+        let calendar = Calendar(identifier: .gregorian)
+
         let today = Date()
         let todayStartOfDay = today.dateBySetting(hour: 0, minute: 0, second: 0)!
-        let todayComps = Calendar.current.dateComponents(calendarComponents, from: today)
-        let todayStartOfDayComps = Calendar.current.dateComponents(calendarComponents, from: todayStartOfDay)
+        let todayComps = calendar.dateComponents(calendarComponents, from: today)
+        let todayStartOfDayComps = calendar.dateComponents(calendarComponents, from: todayStartOfDay)
 
         XCTAssertEqual(todayStartOfDayComps.year, todayComps.year, "Year changed!")
         XCTAssertEqual(todayStartOfDayComps.month, todayComps.month, "Month changed!")

--- a/Tests/SugarTests/XCTestManifests.swift
+++ b/Tests/SugarTests/XCTestManifests.swift
@@ -16,10 +16,17 @@ extension StrongPasswordValidatorTests {
     ]
 }
 
+extension DateTests {
+    static let __allTests = [
+        ("testDateBySettingHourMinuteSecond", testDateBySettingHourMinuteSecond)
+    ]
+}
+
 #if !os(macOS)
 public func __allTests() -> [XCTestCaseEntry] {
     return [
         testCase(StrongPasswordValidatorTests.__allTests),
+        testCase(DateTests.__allTests),
     ]
 }
 #endif


### PR DESCRIPTION
* Adds a test for `dateBySetting(hour:minute:second:calendar:)`
* Adds CircleCI configs for Swift 5 as well
* Fixes `dateBySetting(hour:minute:second:calendar:)` on Linux Swift 5 (works around an issue with default calendar, see https://github.com/apple/swift-corelibs-foundation/pull/2067)
